### PR TITLE
[fix]Visual Studioの文字エンコードをUTF-8 BOM付き(シグネチャ付き)に変更

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.cs]
+charset = utf-8-BOM


### PR DESCRIPTION
文字化け回避のため文字エンコードを変更

# 関連issue
#8 

# 新機能
 

# 機能修正


# 確認事項・確認手順


# 備考
