### PR TITLE
[feature]ステージ外オブジェクトに触れるとプレイヤーが死ぬ機能を実装

### DIFF
--- a/Assets/Rise/Scenes/MainGame/MainGame.unity
+++ b/Assets/Rise/Scenes/MainGame/MainGame.unity
@@ -134,6 +134,7 @@ GameObject:
   - component: {fileID: 19708170}
   - component: {fileID: 19708169}
   - component: {fileID: 19708171}
+  - component: {fileID: 19708172}
   m_Layer: 0
   m_Name: OutSideStage
   m_TagString: Untagged
@@ -232,6 +233,19 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &19708172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 19708168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 597ebd27d67fcf346a900e036900c0df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_causeOfDeathType: 0
 --- !u!4 &180034105 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6283140259448163271, guid: 0e1ca8f4cc18e30438ce146721244d03, type: 3}
@@ -578,7 +592,7 @@ GameObject:
   - component: {fileID: 2119168053}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Rise/Scenes/MainGame/Scripts/FollowCamera.cs
+++ b/Assets/Rise/Scenes/MainGame/Scripts/FollowCamera.cs
@@ -10,7 +10,10 @@ public class FollowCamera : MonoBehaviour
 
     private void Update()
     {
-        MoveCamera();
+        if (m_playerObj != null)
+        {
+            MoveCamera();
+        }
     }
 
     /// <summary>

--- a/Assets/Rise/Scenes/MainGame/Scripts/Gimmick.cs
+++ b/Assets/Rise/Scenes/MainGame/Scripts/Gimmick.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class Gimmick : MonoBehaviour
+{
+    [SerializeField, Header("死因")]
+    private CauseOfDeathType m_causeOfDeathType;
+}

--- a/Assets/Rise/Scenes/MainGame/Scripts/Gimmick.cs.meta
+++ b/Assets/Rise/Scenes/MainGame/Scripts/Gimmick.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c95c12a81788a50488d467cc623750e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Rise/Scenes/MainGame/Scripts/OutSideStage.cs
+++ b/Assets/Rise/Scenes/MainGame/Scripts/OutSideStage.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(BoxCollider2D))]
+public class OutSideStage : Gimmick
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player"))
+        {
+            Destroy(collision.gameObject);
+        }
+    }
+}

--- a/Assets/Rise/Scenes/MainGame/Scripts/OutSideStage.cs.meta
+++ b/Assets/Rise/Scenes/MainGame/Scripts/OutSideStage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 597ebd27d67fcf346a900e036900c0df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 関連issue
#30 

# 新機能
 プレイヤーがステージ外オブジェクト(OutSideStage)に触れると死ぬ機能を実装

# 機能修正


# 確認事項・確認手順

- [x] Assets\Rise\Scenes\MainGame\Scripts\FollowCamera.cs
- [x] Assets\Rise\Scenes\MainGame\Scripts\Gimmick.cs
- [x] Assets\Rise\Scenes\MainGame\Scripts\OutSideStage.cs

# 備考
ステージ外オブジェクトを1つだけ配置。とりあえず触れたら死ぬまでを基本として準備しました。
