### PR TITLE
[feature]プレイヤーにスキルを与える機能を追加

### DIFF
--- a/Assets/Rise/Scenes/MainGame/Scripts/SkillDBEntity.cs
+++ b/Assets/Rise/Scenes/MainGame/Scripts/SkillDBEntity.cs
@@ -7,4 +7,6 @@ public class SkillDBEntity : ScriptableObject
 {
     // スキルのデータベース
     public List<Skill> m_skills = new List<Skill>();
+
+    public List<Skill> Skills => m_skills;
 }

--- a/Assets/Rise/Scenes/MainGame/Scripts/SkillProvider.cs
+++ b/Assets/Rise/Scenes/MainGame/Scripts/SkillProvider.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SkillProvider : MonoBehaviour
+{
+    [SerializeField, Header("スキルデータベース")]
+    private SkillDBEntity m_skillDBEntity;
+
+    public void PassSkill(IInheritable player, CauseOfDeathType causeOfDeathType)
+    {
+        var inheritable = player;
+        foreach (var skill in m_skillDBEntity.Skills)
+        {
+            if (skill.CauseOfDeathType == causeOfDeathType)
+            {
+                inheritable.Inherit(skill);
+            }
+        }
+    }
+}

--- a/Assets/Rise/Scenes/MainGame/Scripts/SkillProvider.cs.meta
+++ b/Assets/Rise/Scenes/MainGame/Scripts/SkillProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3075e2b45329384e8f2a9c0b3fd3920
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION


# 関連issue
#31 

# 新機能
 プレイヤーが継承するスキルを受け取る必要があるため、スキルを与えるSkillProviderスクリプトを追加。SkillDBEntityのデータベースをプロパティ化

# 機能修正


# 確認事項・確認手順

- [ ] Assets\Rise\Scenes\MainGame\Scripts\SkillDBEntity.cs
- [ ] Assets\Rise\Scenes\MainGame\Scripts\SkillProvider.cs

# 備考

