### PR TITLE
[feature]MainGameSceneでプレイヤーが死ぬとSkillSceneに遷移する機能を追加

### DIFF
--- a/Assets/SO/Skill/ThornDisablement.asset
+++ b/Assets/SO/Skill/ThornDisablement.asset
@@ -16,4 +16,3 @@ MonoBehaviour:
   m_skillName: "\u30C8\u30B2\u7121\u52B9"
   m_skillDescription: "\u30C8\u30B2\u30C0\u30E1\u30FC\u30B8\u3067\u6B7B\u306A\u306A\u304F\u306A\u308B\uFF01"
   m_isInherited: 0
-  m_causeOfDeathType: 1

--- a/Assets/Scenes/Skill.unity
+++ b/Assets/Scenes/Skill.unity
@@ -206,3 +206,48 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2146824948
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2146824950}
+  - component: {fileID: 2146824949}
+  m_Layer: 0
+  m_Name: SkillSceneManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2146824949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146824948}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4da6f035028ef14b815037507339184, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_thornDisablementSkill: {fileID: 11400000, guid: 48915dced26724b4ea15fb77a526e3b1, type: 2}
+  m_jumpPowerEnhancementSkill: {fileID: 11400000, guid: da5a0610d1297f14dafec658f1f05920, type: 2}
+--- !u!4 &2146824950
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146824948}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/PlayerKillManager.cs
+++ b/Assets/Scripts/PlayerKillManager.cs
@@ -30,5 +30,6 @@ public class PlayerKillManager
         inheritance.InheritSkill();
         // プレイヤーをDestroyする関数呼び出し
         m_gimmick.PlayerKill(m_player);
+        SceneTransManager.TransToSkill();
     }
 }

--- a/Assets/Scripts/SkillSceneManager.cs
+++ b/Assets/Scripts/SkillSceneManager.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SkillSceneManager : MonoBehaviour
+{
+    [SerializeField, Header("トゲ無効スキル")]
+    private Skill m_thornDisablementSkill;
+    [SerializeField, Header("ジャンプ力強化スキル")]
+    private Skill m_jumpPowerEnhancementSkill;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        Debug.Log($"トゲ無効スキルの継承状態がリセットされていないか:{m_thornDisablementSkill.IsInherited}");
+        Debug.Log($"ジャンプ力強化スキルの継承状態がリセットされていないか:{m_jumpPowerEnhancementSkill.IsInherited}");
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetMouseButtonDown(0))
+        {
+            SceneTransManager.TransToMainGame();
+        }
+    }
+}

--- a/Assets/Scripts/SkillSceneManager.cs.meta
+++ b/Assets/Scripts/SkillSceneManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4da6f035028ef14b815037507339184
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -24,6 +24,9 @@ EditorUserSettings:
       value: 22424703114646680e0b0227036c6b19021b1d6439262f2434
       flags: 0
     RecentlyUsedScenePath-6:
+      value: 22424703114646680e0b0227036c6c1b1f1b146439262f2434
+      flags: 0
+    RecentlyUsedScenePath-7:
       value: 22424703114646680e0b0227036c72111f193f2b212d68252320092a
       flags: 0
     vcSharedLogLevel:


### PR DESCRIPTION
プレイヤーが死んでもSkillSceneに遷移しなかったため実装

# 関連issue
Closes #29 

# 新機能

- [x] MainGameSceneでプレイヤーが死ぬとSkillSceneに遷移する機能を実装
- [x] SkillSceneで左クリックするとMainGameSceneに遷移する機能を実装

# 機能修正


# 確認事項・確認手順

- [x] Assets\Scripts\PlayerKillManager.cs
- [x] Assets\Scripts\SkillSceneManager.cs

# 備考
SkillSceneに遷移すると、スキルの継承状態が引き継がれていないorリセットされている現象が起きたため、自分用に確認Debugを追加しています。現在は安定して引き継がれています。
