### PR TITLE
[fix]スキル継承が安定して行われない問題を解消

### DIFF
--- a/Assets/Scripts/SkillSceneManager.cs
+++ b/Assets/Scripts/SkillSceneManager.cs
@@ -4,18 +4,6 @@ using UnityEngine;
 
 public class SkillSceneManager : MonoBehaviour
 {
-    [SerializeField, Header("トゲ無効スキル")]
-    private Skill m_thornDisablementSkill;
-    [SerializeField, Header("ジャンプ力強化スキル")]
-    private Skill m_jumpPowerEnhancementSkill;
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        Debug.Log($"トゲ無効スキルの継承状態がリセットされていないか:{m_thornDisablementSkill.IsInherited}");
-        Debug.Log($"ジャンプ力強化スキルの継承状態がリセットされていないか:{m_jumpPowerEnhancementSkill.IsInherited}");
-    }
-
     // Update is called once per frame
     void Update()
     {


### PR DESCRIPTION
スキル効果からスキルへの参照が実行中に外れていたため修正した

# 関連issue
close #85 

# 新機能
 

# 機能修正

- スキル効果からスキルへの参照が実行中に外れていたため参照を割り当て直した
- SkillSceneManagerクラスから各スキルへの参照を削除

# 確認事項・確認手順

- [ ] Assets\Scripts\SkillSceneManager.cs

# 備考

