### PR TITLE
[feature]直前のメインゲームシーンに遷移する機能を実装

### DIFF
--- a/Assets/Scripts/MainGameManager.cs
+++ b/Assets/Scripts/MainGameManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class MainGameManager : MonoBehaviour
 {
@@ -14,6 +15,7 @@ public class MainGameManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        SceneTransManager.LatestSceneName = SceneManager.GetActiveScene().name;
         m_playerController.Init();
 
         // スキルの効果を発動する関数呼び出し

--- a/Assets/Scripts/SceneTransManager.cs
+++ b/Assets/Scripts/SceneTransManager.cs
@@ -8,6 +8,11 @@ using UnityEngine.SceneManagement;
 /// </summary>
 public class SceneTransManager
 {
+    // 直前のメインゲームシーン名
+    private static string m_latestSceneName;
+
+    public static string LatestSceneName { get { return m_latestSceneName; } set { m_latestSceneName = value; } }
+
     /// <summary>
     /// メインゲームシーンに遷移する
     /// </summary>
@@ -38,5 +43,13 @@ public class SceneTransManager
     public static void TransToSkill()
     {
         SceneManager.LoadScene("Skill");
+    }
+
+    /// <summary>
+    /// 直前のメインゲームシーンに遷移する
+    /// </summary>
+    public static void TransToMainGameLatest()
+    {
+        SceneManager.LoadScene(LatestSceneName);
     }
 }

--- a/Assets/Scripts/SkillSceneManager.cs
+++ b/Assets/Scripts/SkillSceneManager.cs
@@ -21,7 +21,7 @@ public class SkillSceneManager : MonoBehaviour
     {
         if (Input.GetMouseButtonDown(0))
         {
-            SceneTransManager.TransToStage1();
+            SceneTransManager.TransToMainGameLatest();
         }
     }
 }


### PR DESCRIPTION
close #81

# 関連issue
close #85 

# 新機能

-  スキル継承画面から直前のメインゲームシーンに遷移する機能を実装

# 機能修正


# 確認事項・確認手順

- [x] Assets\Scripts\MainGameManager.cs
- [x] Assets\Scripts\SceneTransManager.cs
- [ ] Assets\Scripts\SkillSceneManager.cs

# 備考

