### PR TITLE
[fix]プレイヤーを倒す関数をエネミーとギミックで抽象化

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public abstract class Enemy : MonoBehaviour
 {
     [SerializeField, Header("スキル")]
-    private Skill m_skill;
+    protected Skill m_skill;
 
     /// <summary>
     /// プレイヤーをDestroyする

--- a/Assets/Scripts/FireCurtain.cs
+++ b/Assets/Scripts/FireCurtain.cs
@@ -40,8 +40,8 @@ public class FireCurtain : Gimmick
 
     public override void ExecutePlayerKillManager(Player player)
     {
-        var playerKillManager = new PlayerKillManager(this, player);
-        playerKillManager.PlayerKill(m_skill);
+        var playerKillManager = new PlayerKillManager(player);
+        playerKillManager.PlayerKill(this, m_skill);
     }
 
     public override void PlayerKill(Player player)

--- a/Assets/Scripts/OutSideStage.cs
+++ b/Assets/Scripts/OutSideStage.cs
@@ -20,8 +20,8 @@ public class OutSideStage : Gimmick
 
     public override void ExecutePlayerKillManager(Player player)
     {
-        var playerKillManager = new PlayerKillManager(this, player);
-        playerKillManager.PlayerKill(m_skill);
+        var playerKillManager = new PlayerKillManager(player);
+        playerKillManager.PlayerKill(this, m_skill);
     }
 
     public override void PlayerKill(Player player)

--- a/Assets/Scripts/PlayerKillManager.cs
+++ b/Assets/Scripts/PlayerKillManager.cs
@@ -7,29 +7,41 @@ using UnityEngine;
 /// </summary>
 public class PlayerKillManager
 {
-    //ギミック
-    private Gimmick m_gimmick;
     // プレイヤー
     private Player m_player;
 
-    public PlayerKillManager(Gimmick gimmick, Player player)
+    public PlayerKillManager(Player player)
     {
-        m_gimmick = gimmick;
         m_player = player;
     }
 
     /// <summary>
-    /// プレイヤーを倒す一連の処理
+    /// エネミーがプレイヤーを倒す一連の処理
+    /// </summary>
+    /// <param name="enemy"></param>
+    /// <param name="skill"></param>
+    public void PlayerKill(Enemy enemy, Skill skill)
+    {
+        var inheritance = new Inheritance(skill);
+
+        inheritance.InheritSkill();
+
+        enemy.PlayerKill(m_player);
+        SceneTransManager.TransToSkill();
+    }
+
+    /// <summary>
+    /// ギミックがプレイヤーを倒す一連の処理
     /// </summary>
     /// <param name="player"></param>
     /// <param name="causeOfDeathType"></param>
-    public void PlayerKill(Skill skill)
+    public void PlayerKill(Gimmick gimmick, Skill skill)
     {
         var inheritance = new Inheritance(skill);
         // スキル継承クラスのスキルを継承させる関数呼び出し
         inheritance.InheritSkill();
         // プレイヤーをDestroyする関数呼び出し
-        m_gimmick.PlayerKill(m_player);
+        gimmick.PlayerKill(m_player);
         SceneTransManager.TransToSkill();
     }
 }

--- a/Assets/Scripts/ThornFloor.cs
+++ b/Assets/Scripts/ThornFloor.cs
@@ -26,8 +26,8 @@ public class ThornFloor : Gimmick
     /// <param name="player"></param>
     public override void ExecutePlayerKillManager(Player player)
     {
-        var playerKillManager = new PlayerKillManager(this, player);
-        playerKillManager.PlayerKill(m_skill);
+        var playerKillManager = new PlayerKillManager(player);
+        playerKillManager.PlayerKill(this, m_skill);
     }
 
     /// <summary>


### PR DESCRIPTION
close #88 プレイヤーを倒す関数がエネミー側とギミック側で意識してコードを書く必要がないので関数をオーバーロードした

# 関連issue
Closes #88 

# 新機能
 

# 機能修正


# 確認事項・確認手順

- [x] Assets\Scripts\Enemy.cs
- [x] Assets\Scripts\FireCurtain.cs
- [x] Assets\Scripts\OutSideStage.cs
- [x] Assets\Scripts\PlayerKillManager.cs
- [x] Assets\Scripts\ThornFloor.cs

# 備考

