### PR TITLE
[feature]すり抜け床を実装

### DIFF
--- a/Assets/Prefabs/Floor.prefab
+++ b/Assets/Prefabs/Floor.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5999225384685153856}
   - component: {fileID: 5999225384685153858}
   - component: {fileID: 5999225384685153859}
+  - component: {fileID: 4902706565898760496}
   m_Layer: 3
   m_Name: Floor
   m_TagString: Untagged
@@ -94,7 +95,7 @@ BoxCollider2D:
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_UsedByEffector: 0
+  m_UsedByEffector: 1
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
@@ -109,3 +110,22 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!251 &4902706565898760496
+PlatformEffector2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5999225384685153857}
+  m_Enabled: 1
+  m_UseColliderMask: 1
+  m_ColliderMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RotationalOffset: 0
+  m_UseOneWay: 1
+  m_UseOneWayGrouping: 0
+  m_SurfaceArc: 180
+  m_UseSideFriction: 0
+  m_UseSideBounce: 0
+  m_SideArc: 1


### PR DESCRIPTION
close #92 下からジャンプした際に床にプレイヤーの頭が衝突してしまうため、すり抜け床を実装した

# 関連issue
Closes #92 

# 新機能

-  下からジャンプするとすり抜ける床を実装した

# 機能修正


# 確認事項・確認手順

- [x] Assets\Prefabs\Floor.prefab

# 備考

