### PR TITLE
[feature]リトライボタンを押すと直前のStageシーンに遷移する機能を実装

### DIFF
--- a/Assets/Scenes/Skill.unity
+++ b/Assets/Scenes/Skill.unity
@@ -1188,7 +1188,7 @@ GameObject:
   - component: {fileID: 1700211443}
   - component: {fileID: 1700211442}
   m_Layer: 5
-  m_Name: Button
+  m_Name: RetryButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1257,7 +1257,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1700211443}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2146824949}
+        m_TargetAssemblyTypeName: SkillSceneManager, Assembly-CSharp
+        m_MethodName: OnRetry
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1700211443
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1309,7 +1321,7 @@ GameObject:
   - component: {fileID: 1904357608}
   - component: {fileID: 1904357607}
   m_Layer: 5
-  m_Name: Button (1)
+  m_Name: BackToTitleButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/SkillSceneManager.cs
+++ b/Assets/Scripts/SkillSceneManager.cs
@@ -16,12 +16,11 @@ public class SkillSceneManager : MonoBehaviour
         Debug.Log($"ジャンプ力強化スキルの継承状態がリセットされていないか:{m_jumpPowerEnhancementSkill.IsInherited}");
     }
 
-    // Update is called once per frame
-    void Update()
+    /// <summary>
+    /// リトライする
+    /// </summary>
+    public void OnRetry()
     {
-        if (Input.GetMouseButtonDown(0))
-        {
-            SceneTransManager.TransToMainGameLatest();
-        }
+        SceneTransManager.TransToMainGameLatest();
     }
 }


### PR DESCRIPTION
リトライボタンに遷移機能の実装がなかったため実装した

# 関連issue
#97 

# 新機能

-  リトライボタンを押すと直前のStageシーンに遷移する機能を実装

# 機能修正


# 確認事項・確認手順

- [x] Assets\Scenes\Skill.unity
- [x] Assets\Scripts\SkillSceneManager.cs

# 備考
SkillSceneManagerクラスからUpdate関数と左クリックを押すと遷移する処理を削除しました
