### PR TITLE
[feature]タイトルに戻るボタンを押すとタイトル画面に遷移する機能を実装

### DIFF
--- a/Assets/Scenes/Skill.unity
+++ b/Assets/Scenes/Skill.unity
@@ -1390,7 +1390,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1904357608}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2146824949}
+        m_TargetAssemblyTypeName: SkillSceneManager, Assembly-CSharp
+        m_MethodName: BackToTitle
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1904357608
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SceneTransManager.cs
+++ b/Assets/Scripts/SceneTransManager.cs
@@ -14,6 +14,14 @@ public class SceneTransManager
     public static string LatestSceneName { get { return m_latestSceneName; } set { m_latestSceneName = value; } }
 
     /// <summary>
+    /// タイトルシーンに遷移する
+    /// </summary>
+    public static void TransToTitle()
+    {
+        SceneManager.LoadScene("Title");
+    }
+
+    /// <summary>
     /// メインゲームシーンに遷移する
     /// </summary>
     public static void TransToStage1()

--- a/Assets/Scripts/SkillSceneManager.cs
+++ b/Assets/Scripts/SkillSceneManager.cs
@@ -23,4 +23,12 @@ public class SkillSceneManager : MonoBehaviour
     {
         SceneTransManager.TransToMainGameLatest();
     }
+
+    /// <summary>
+    /// タイトルに戻る
+    /// </summary>
+    public void BackToTitle()
+    {
+        SceneTransManager.TransToTitle();
+    }
 }


### PR DESCRIPTION
タイトルに戻るボタンに遷移機能を実装していなかったため実装した

# 関連issue
#97 

# 新機能

-  タイトルに戻るボタンを押すとタイトル画面に遷移する機能を実装

# 機能修正


# 確認事項・確認手順

- [x] Assets\Scenes\Skill.unity
- [x] Assets\Scripts\SceneTransManager.cs
- [x] Assets\Scripts\SkillSceneManager.cs

# 備考
SceneTransManagerクラスにタイトルシーンに遷移する関数がなかったためBackToTitle関数とタイトルシーンに遷移する処理を追加しました
