### PR TITLE
[feature]クリボーに触れるとプレイヤーが死ぬ機能を実装

### DIFF
--- a/Assets/Prefabs/Kuribo.prefab
+++ b/Assets/Prefabs/Kuribo.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5352779641257991251}
   - component: {fileID: 5352779641257991248}
   - component: {fileID: 4893474853453732582}
+  - component: {fileID: 2349674571809091435}
   m_Layer: 0
   m_Name: Kuribo
   m_TagString: Enemy
@@ -109,3 +110,16 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &2349674571809091435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5352779641257991249}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f25925c27e17ed449ff83ed8b1d3220, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_skill: {fileID: 11400000, guid: da5a0610d1297f14dafec658f1f05920, type: 2}

--- a/Assets/Scripts/Kuribo.cs
+++ b/Assets/Scripts/Kuribo.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Kuribo : Enemy
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player"))
+        {
+            var player = collision.GetComponent<Player>();
+
+            if (player != null)
+            {
+                ExecutePlayerKillManager(player);
+            }
+        }
+    }
+
+    public override void ExecutePlayerKillManager(Player player)
+    {
+        var playerKillManager = new PlayerKillManager(player);
+        playerKillManager.PlayerKill(this, m_skill);
+    }
+
+    public override void PlayerKill(Player player)
+    {
+        Destroy(player.gameObject);
+    }
+}

--- a/Assets/Scripts/Kuribo.cs.meta
+++ b/Assets/Scripts/Kuribo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f25925c27e17ed449ff83ed8b1d3220
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
クリボーに触れてもプレイヤーが死ぬ機能がなかったため実装した

# 関連issue
#15 

# 新機能

-  クリボーに触れるとプレイヤーが死ぬ機能を実装

# 機能修正


# 確認事項・確認手順

- [x] Assets\Prefabs\Kuribo.prefab
- [x] Assets\Scripts\Kuribo.cs

# 備考
クリボーから継承できるスキルを実装していないため、現状ではプレイヤーが触れても死にません
