### PR TITLE
[fix]追従カメラが一定以上低い位置には追従しないように修正する

### DIFF
--- a/Assets/Scenes/Stage1.unity
+++ b/Assets/Scenes/Stage1.unity
@@ -320,7 +320,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -7.96
+      value: -9.34
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.z
@@ -785,7 +785,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 605817101}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 60.2, y: 2.12, z: 0}
+  m_LocalPosition: {x: 60.2, y: 1.4, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 712128206}
@@ -836,7 +836,7 @@ SpriteRenderer:
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 2
-  m_Size: {x: 210.62, y: 17.3}
+  m_Size: {x: 210.62, y: 19.37}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 1
   m_WasSpriteAssigned: 1
@@ -1164,7 +1164,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -7.96
+      value: -9.34
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1812,7 +1812,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -7.96
+      value: -9.34
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2568,7 +2568,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -7.96
+      value: -9.34
       objectReference: {fileID: 0}
     - target: {fileID: 7742602097893594466, guid: 14941b5fb525cef45ac5e6d705b62a40, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/FollowCamera.cs
+++ b/Assets/Scripts/FollowCamera.cs
@@ -22,6 +22,13 @@ public class FollowCamera : MonoBehaviour
     private void MoveCamera()
     {
         var playerPos = m_playerObj.transform.position;
-        transform.position = new Vector3(playerPos.x, playerPos.y, transform.position.z);
+        if (playerPos.y < -3f)
+        {
+            return;
+        }
+        else
+        {
+            transform.position = new Vector3(playerPos.x, playerPos.y, transform.position.z);
+        }
     }
 }


### PR DESCRIPTION
プレイヤーが落とし穴に落ちた際、追従カメラがステージ外オブジェクトの高さまで追従していたため修正

# 関連issue
Closes #108 

# 新機能
 

# 機能修正

- 追従カメラが一定以上低い位置には追従しないように修正する

# 確認事項・確認手順

- [x] Assets\Scenes\Stage1.unity
- [x] Assets\Scripts\FollowCamera.cs

# 備考
ステージ1の背景オブジェクトの高さを変更しました
