### PR TITLE
[fix]地面の色を変更

### DIFF
--- a/Assets/Prefabs/Ground.prefab
+++ b/Assets/Prefabs/Ground.prefab
@@ -73,7 +73,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.735849, g: 0.50199586, b: 0.2950338, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0


### PR DESCRIPTION
Groundプレハブの色がデフォルトだったため変更した

# 関連issue


# 新機能
 

# 機能修正


# 確認事項・確認手順

- [ ] Assets\Prefabs\Ground.prefab

# 備考

