### PR TITLE
敵の移動する向きが変わる機能追加

### DIFF
--- a/Assets/Prefabs/Togezo.prefab
+++ b/Assets/Prefabs/Togezo.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 8994545303218900434}
   m_Layer: 0
   m_Name: Togezo
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Wall1.prefab
+++ b/Assets/Prefabs/Wall1.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 6876436197685197663}
   m_Layer: 0
   m_Name: Wall1
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Wall2.prefab
+++ b/Assets/Prefabs/Wall2.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 936431335426548857}
   m_Layer: 6
   m_Name: Wall2
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Stage1.unity
+++ b/Assets/Scenes/Stage1.unity
@@ -423,6 +423,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Togezo
       objectReference: {fileID: 0}
+    - target: {fileID: 4745542514267478917, guid: bed37fff1767ea140b6d96dc37e7dfa3, type: 3}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bed37fff1767ea140b6d96dc37e7dfa3, type: 3}
 --- !u!4 &180034105 stripped
@@ -495,6 +499,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Togezo (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4745542514267478917, guid: bed37fff1767ea140b6d96dc37e7dfa3, type: 3}
+      propertyPath: m_TagString
+      value: Enemy
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bed37fff1767ea140b6d96dc37e7dfa3, type: 3}
 --- !u!4 &316497612 stripped
@@ -513,7 +521,7 @@ GameObject:
   - component: {fileID: 385810819}
   m_Layer: 0
   m_Name: '#Wall'
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2413,6 +2421,10 @@ PrefabInstance:
     - target: {fileID: 936431335426548856, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_Name
       value: Wall2
+      objectReference: {fileID: 0}
+    - target: {fileID: 936431335426548856, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
+      propertyPath: m_TagString
+      value: Wall
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -16,6 +16,9 @@ public class EnemyController : MonoBehaviour
     private Vector2 velocity;
 
     private bool grounded;
+
+    //通常のサイズ
+    private Vector2 defaultSize;
     #endregion
 
     #region Initialize
@@ -23,6 +26,8 @@ public class EnemyController : MonoBehaviour
     {
         m_rb = GetComponent<Rigidbody2D>();
         boxCollider = GetComponent<BoxCollider2D>();
+
+        defaultSize = transform.localScale;
     }
     #endregion
 
@@ -30,7 +35,10 @@ public class EnemyController : MonoBehaviour
     // Update is called once per frame
     void Update ()
     {
-       Walk();
+        Walk();
+
+        //サイズ更新
+        transform.localScale = defaultSize;
     }
     #endregion
 
@@ -49,9 +57,11 @@ public class EnemyController : MonoBehaviour
     private void OnCollisionEnter2D(Collision2D collision)
     {
         if (collision.gameObject.tag == "Wall" ||
-            collision.gameObject.tag == "Player")
+            collision.gameObject.tag == "Player"||
+            collision.gameObject.tag == "Enemy")
         {
             m_walkSpeed *= -1;
+            defaultSize.x *= -1;
         }
     }
     #endregion

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Enemy
+  - Wall
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
# 関連issue

# 新機能
- 敵が当たり判定のものと当たったら向きが変わる
- 壁のタグ追加

# 機能修正
- プレハブの棘の敵のタグの設定
- プレハブの壁のタグ設定
- ステージ1の配置されてるタグの設定

# 確認事項・確認手順

# 備考
