### PR TITLE
[fix]プレイヤーが火に耐えるカウントを衝突中の経過時間から衝突した回数に変更

### DIFF
--- a/Assets/Prefabs/FireBall.prefab
+++ b/Assets/Prefabs/FireBall.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 8450119099031781868}
   - component: {fileID: 6212282639586996835}
   - component: {fileID: 6852501940670035421}
+  - component: {fileID: 1953276984409254907}
   m_Layer: 0
   m_Name: FireBall
   m_TagString: Untagged
@@ -115,9 +116,22 @@ CircleCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.49999997
+--- !u!114 &1953276984409254907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8450119099031781875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e344508b751714e4c9fc314c6c030c45, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_skill: {fileID: 11400000, guid: d7ac29a7ccd42f84a9308db246b58407, type: 2}

--- a/Assets/SO/Skill/BurnoutResistance.asset
+++ b/Assets/SO/Skill/BurnoutResistance.asset
@@ -15,4 +15,4 @@ MonoBehaviour:
   m_skillID: 3
   m_skillName: "\u713C\u6B7B\u8010\u6027"
   m_skillDescription: "\u708E\u30C0\u30E1\u30FC\u30B8\u306B3\u79D2\u9593\u8010\u3048\u3089\u308C\u308B\u3088\u3046\u306B\u306A\u308B\uFF01"
-  m_isInherited: 0
+  m_deathType: 3

--- a/Assets/Scripts/BurnoutResistance.cs
+++ b/Assets/Scripts/BurnoutResistance.cs
@@ -6,16 +6,21 @@ using UnityEngine;
     fileName = "BurnoutResistanceEffect")]
 public class BurnoutResistance : SkillEffect
 {
+    [SerializeField, Header("火に耐えられる回数(通常時)")]
+    private int m_normalEnduranceCount;
+    [SerializeField, Header("火に耐えられる回数(焼死耐性時)")]
+    private int m_enduranceCountAtResistance;
+
     public override void InvokeSkill(Player player)
     {
-        // スキルが継承されていれば焼死耐性を有効にする
+        // スキルが継承されていれば火に耐えられる回数を5にする
         if (Player.m_inheritedSkills.Find(x => x.SkillName == "焼死耐性"))
         {
-            player.IsBurnoutResistanceEnabled = true;
+            player.EnduranceCount = m_enduranceCountAtResistance;
         }
         else
         {
-            player.IsBurnoutResistanceEnabled = false;
+            player.EnduranceCount = m_normalEnduranceCount;
         }
     }
 }

--- a/Assets/Scripts/FireBall.cs
+++ b/Assets/Scripts/FireBall.cs
@@ -12,7 +12,16 @@ public class FireBall : Gimmick
 
             if (player != null)
             {
-                ExecutePlayerKillManager(player);
+                Debug.Log(player.EnduranceCount);
+                if (player.EnduranceCount == 0)
+                {
+                    ExecutePlayerKillManager(player);
+                }
+                else
+                {
+                    player.EnduranceCount -= 1;
+                    Destroy(gameObject);
+                }
             }
         }
     }

--- a/Assets/Scripts/FireCurtain.cs
+++ b/Assets/Scripts/FireCurtain.cs
@@ -11,28 +11,15 @@ public class FireCurtain : Gimmick
             var player = collision.GetComponent<Player>();
 
             // playerがnullじゃない、かつ焼死耐性スキルが継承されていなければ実行
-            if (player != null && !player.IsBurnoutResistanceEnabled)
+            if (player != null)
             {
-                ExecutePlayerKillManager(player);
-            }
-        }
-    }
-
-    private void OnTriggerStay2D(Collider2D collision)
-    {
-        if (collision.CompareTag("Player"))
-        {
-            var player = collision.GetComponent<Player>();
-
-            // playerがnullじゃない、かつ焼死耐性スキルが継承されていれば実行
-            if (player != null && player.IsBurnoutResistanceEnabled)
-            {
-                // プレイヤーが火に耐えられる時間を減らす
-                player.FireCount -= 1f * Time.deltaTime;
-
-                if (player.FireCount <= 0f)
+                if (player.EnduranceCount == 0)
                 {
                     ExecutePlayerKillManager(player);
+                }
+                else
+                {
+                    player.EnduranceCount -= 1;
                 }
             }
         }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -7,8 +7,8 @@ public class Player : MonoBehaviour
 {
     [SerializeField, Header("ジャンプ力")]
     private float m_jumpPower;
-    [SerializeField, Header("炎に耐えられる時間")]
-    private float m_FireCount;
+    // 火に耐えられる回数
+    private int m_enduransCount;
     // 残機
     private static int m_remain = 3;
     // 継承中のスキル
@@ -17,9 +17,8 @@ public class Player : MonoBehaviour
     public float JumpPower { get { return m_jumpPower; } set { m_jumpPower = value; } }
     // トゲ無効スキルが有効かどうか
     public bool IsThornDisablementEnabled { get; set; }
-    // 焼死耐性スキルが有効かどうか
-    public bool IsBurnoutResistanceEnabled { get; set; }
-    public float FireCount { get { return m_FireCount; } set { m_FireCount = value; } }
+    // 火に耐えられる回数
+    public int EnduranceCount { get { return m_enduransCount; } set { m_enduransCount = value; } }
     public bool IsDefeatTheKuriboEnabled { get; set; }
     // 残機
     public static int Remain { get { return m_remain; } set { m_remain = value; } }


### PR DESCRIPTION
# 関連issue
Closes #127 

# 新機能
 

# 機能修正

- プレイヤー火に耐えるカウント方法を衝突中の経過時間から衝突した回数に変更した

# 確認事項・確認手順

- [x] Assets\Prefabs\FireBall.prefab
- [x] Assets\Scripts\BurnoutResistance.cs
- [x] Assets\Scripts\FireBall.cs
- [x] Assets\Scripts\FireCurtain.cs
- [x] Assets\Scripts\Player.cs
- [x] Assets\SO\Skill\BurnoutResistance.asset

# 備考
火に耐えられる回数の調整は通常時、焼死耐性継承時共にBurnoutResistanceEffectアセットからできます。
