### PR TITLE
[fix]爆発エフェクトのコライダーサイズを修正

### DIFF
--- a/Assets/Prefabs/Explosion.prefab
+++ b/Assets/Prefabs/Explosion.prefab
@@ -4842,4 +4842,4 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 4
+  m_Radius: 1


### PR DESCRIPTION
close #137 爆発エフェクトのコライダーサイズが大きすぎたため修正した

# 関連issue
Closes #137 

# 新機能
 

# 機能修正


# 確認事項・確認手順

- [x] Assets\Prefabs\Explosion.prefab

# 備考

