### PR TITLE
[fix]ステージ2終盤の火のカーテンの噴射間隔を調整

### DIFF
--- a/Assets/Scenes/Stage2.unity
+++ b/Assets/Scenes/Stage2.unity
@@ -3108,6 +3108,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2088060088}
     m_Modifications:
+    - target: {fileID: 1866413697655828996, guid: 4f7d81470e7c9b444868ed76a8ac8d36, type: 3}
+      propertyPath: m_maxDuration
+      value: 1.5
+      objectReference: {fileID: 0}
     - target: {fileID: 3316106933891882825, guid: 4f7d81470e7c9b444868ed76a8ac8d36, type: 3}
       propertyPath: m_RootOrder
       value: 4


### PR DESCRIPTION
close #145

# 関連issue
Closes #145 

# 新機能
 

# 機能修正

- ステージ2の火のカーテン(FireCurtain(4)、FireCurtain(5))の噴射間隔を変更した

# 確認事項・確認手順

- [x] Assets\Scenes\Stage2.unity

# 備考

