### PR TITLE
[fix]焼死耐性の説明文を変更

### DIFF
--- a/Assets/SO/Skill/FireBall.asset
+++ b/Assets/SO/Skill/FireBall.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_skillID: 3
   m_skillName: "\u713C\u6B7B\u8010\u6027"
-  m_skillDescription: "\u708E\u30C0\u30E1\u30FC\u30B8\u306B3\u79D2\u9593\u8010\u3048\u3089\u308C\u308B\u3088\u3046\u306B\u306A\u308B\uFF01"
-  m_deathType: 3
+  m_skillDescription: "\u708E\u30C0\u30E1\u30FC\u30B8\u306B3\u56DE\u8010\u3048\u3089\u308C\u308B\u3088\u3046\u306B\u306A\u308B\uFF01"
+  m_deathType: 4

--- a/Assets/SO/Skill/FireCurtain.asset
+++ b/Assets/SO/Skill/FireCurtain.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_skillID: 3
   m_skillName: "\u713C\u6B7B\u8010\u6027"
-  m_skillDescription: "\u708E\u30C0\u30E1\u30FC\u30B8\u306B3\u79D2\u9593\u8010\u3048\u3089\u308C\u308B\u3088\u3046\u306B\u306A\u308B\uFF01"
-  m_deathType: 3
+  m_skillDescription: "\u708E\u30C0\u30E1\u30FC\u30B8\u306B3\u56DE\u8010\u3048\u3089\u308C\u308B\u3088\u3046\u306B\u306A\u308B\uFF01"
+  m_deathType: 5

--- a/Assets/SO/SkillEffect/BurnoutResistanceEffect.asset
+++ b/Assets/SO/SkillEffect/BurnoutResistanceEffect.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: BurnoutResistanceEffect
   m_EditorClassIdentifier: 
   m_skill: {fileID: 11400000, guid: d7ac29a7ccd42f84a9308db246b58407, type: 2}
-  m_normalEnduranceCount: 3
-  m_enduranceCountAtResistance: 5
+  m_normalEnduranceCount: 0
+  m_enduranceCountAtResistance: 3


### PR DESCRIPTION


# 関連issue
Closes #148 

# 新機能
 

# 機能修正

- 焼死耐性の説明文が3秒間耐えられるになっていたので、3回耐えられるに変更した

# 確認事項・確認手順

- [x] Assets\SO\Skill\FireBall.asset
- [x] Assets\SO\Skill\FireCurtain.asset
- [x] Assets\SO\SkillEffect\BurnoutResistanceEffect.asset
![スクリーンショット 2022-12-17 172620](https://user-images.githubusercontent.com/92201937/208233151-075d77f3-0da1-4f49-80c9-951ac6288ee9.png)


# 備考
説明文変更文とあわせて焼死耐性スキル継承時の火に対する耐性回数も5回→3回に変更しておきました
