### PR TITLE
[fix]プレイヤーがトゲゾーを押せる問題を修正

### DIFF
--- a/Assets/Prefabs/Togezo.prefab
+++ b/Assets/Prefabs/Togezo.prefab
@@ -186,3 +186,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_walkSpeed: -2
+  m_triggerColl: {fileID: 0}

--- a/Assets/Scenes/Stage2.unity
+++ b/Assets/Scenes/Stage2.unity
@@ -2279,6 +2279,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 92200734}
     m_Modifications:
+    - target: {fileID: 3394349783618383260, guid: bed37fff1767ea140b6d96dc37e7dfa3, type: 3}
+      propertyPath: m_BodyType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4259469727659432882, guid: bed37fff1767ea140b6d96dc37e7dfa3, type: 3}
       propertyPath: m_RootOrder
       value: 0

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -17,6 +17,9 @@ public class EnemyController : MonoBehaviour
 
     private bool grounded;
 
+    [SerializeField, Header("トリガーコライダー")]
+    private BoxCollider2D m_triggerColl;
+
     //通常のサイズ
     private Vector2 defaultSize;
     #endregion
@@ -54,14 +57,22 @@ public class EnemyController : MonoBehaviour
 
 
     #region Collsion
-    private void OnCollisionEnter2D(Collision2D collision)
+    private void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.gameObject.tag == "Wall" ||
-            collision.gameObject.tag == "Player"||
+            collision.gameObject.tag == "Player" ||
             collision.gameObject.tag == "Enemy")
         {
-            m_walkSpeed *= -1;
-            defaultSize.x *= -1;
+            if (transform.localScale.x >= 0 && collision.transform.position.x <= transform.position.x)
+            {
+                m_walkSpeed *= -1;
+                defaultSize.x *= -1;
+            }
+            else if (transform.localScale.x <= 0 && collision.transform.position.x >= transform.position.x)
+            {
+                m_walkSpeed *= -1;
+                defaultSize.x *= -1;
+            }
         }
     }
     #endregion


### PR DESCRIPTION
プレイヤーとトゲゾーが正面から衝突した場合、トゲゾーを押せてしまう問題を修正した

# 関連issue
#15 

# 新機能
 プレイヤーがトゲゾーを押せる問題を修正

# 機能修正

# 確認事項・確認手順

- [x] Assets\Prefabs\Togezo.prefab
- [x] Assets\Scenes\Stage2.unity
- [ ] Assets\Scripts\EnemyController.cs

# 備考

