### PR TITLE
[feature]スキル継承数に上限を追加

### DIFF
--- a/Assets/SO/Skill/DefeatTheKuribo.asset
+++ b/Assets/SO/Skill/DefeatTheKuribo.asset
@@ -15,5 +15,4 @@ MonoBehaviour:
   m_skillID: 4
   m_skillName: "\u30AF\u30EA\u30DC\u30FC\u8E0F\u3093\u3065\u3051"
   m_skillDescription: "\u30AF\u30EA\u30DC\u30FC\u3092\u8E0F\u3093\u3067\u5012\u305B\u308B\u3088\u3046\u306B\u306A\u308B\uFF01"
-  m_isInherited: 1
-  m_deathType: 2
+  m_deathType: 3

--- a/Assets/Scenes/SkillSwap.unity
+++ b/Assets/Scenes/SkillSwap.unity
@@ -262,7 +262,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 490}
+  m_AnchoredPosition: {x: 0, y: 507.5}
   m_SizeDelta: {x: 615, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &366477992
@@ -655,8 +655,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1173399412}
+  m_Children: []
   m_Father: {fileID: 1559532391}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -680,7 +679,7 @@ MonoBehaviour:
   m_Padding:
     m_Left: 0
     m_Right: 0
-    m_Top: 0
+    m_Top: 50
     m_Bottom: 0
   m_ChildAlignment: 4
   m_Spacing: 0
@@ -776,12 +775,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1173399411}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 666400975}
-  m_RootOrder: 0
+  m_Father: {fileID: 1559532391}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -926,6 +925,7 @@ RectTransform:
   - {fileID: 2013242322}
   - {fileID: 418702684}
   - {fileID: 366477991}
+  - {fileID: 1173399412}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/GameClearManager.cs
+++ b/Assets/Scripts/GameClearManager.cs
@@ -9,7 +9,7 @@ public class GameClearManager : MonoBehaviour
         // 継承中のスキルを全削除
         Player.m_inheritedSkills.Clear();
         // 残機をリセット
-        Player.Remain = 3;
+        Player.Life = 3;
     }
 
     /// <summary>

--- a/Assets/Scripts/GameOverManager.cs
+++ b/Assets/Scripts/GameOverManager.cs
@@ -9,7 +9,7 @@ public class GameOverManager : MonoBehaviour
         // 継承中のスキルを全削除
         Player.m_inheritedSkills.Clear();
         // 残機をリセット
-        Player.Remain = 3;
+        Player.Life = 3;
     }
 
     /// <summary>

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -10,11 +10,13 @@ public class Player : MonoBehaviour
     // 火に耐えられる回数
     private int m_enduransCount;
     // 残機
-    private static int m_remain = 3;
+    private static int m_life = 5;
     // 継承中のスキル
     public static List<Skill> m_inheritedSkills = new List<Skill>();
     // 入れ替えスキル
     public static List<Skill> m_swapSkills = new List<Skill>();
+    // スキル継承上限
+    private static int m_inheritanceLimit = 3;
 
     public float JumpPower { get { return m_jumpPower; } set { m_jumpPower = value; } }
     // トゲ無効スキルが有効かどうか
@@ -23,5 +25,7 @@ public class Player : MonoBehaviour
     public int EnduranceCount { get { return m_enduransCount; } set { m_enduransCount = value; } }
     public bool IsDefeatTheKuriboEnabled { get; set; }
     // 残機
-    public static int Remain { get { return m_remain; } set { m_remain = value; } }
+    public static int Life { get { return m_life; } set { m_life = value; } }
+    // スキル継承上限
+    public static int InheritanceLimit { get { return m_inheritanceLimit; } }
 }

--- a/Assets/Scripts/PlayerKillManager.cs
+++ b/Assets/Scripts/PlayerKillManager.cs
@@ -15,6 +15,7 @@ public class PlayerKillManager
         m_player = player;
     }
 
+    #region Enemy
     /// <summary>
     /// エネミーがプレイヤーを倒す一連の処理
     /// </summary>
@@ -22,15 +23,39 @@ public class PlayerKillManager
     /// <param name="skill"></param>
     public void PlayerKill(Enemy enemy, Skill skill)
     {
-        if (Player.Remain != 0)
+        if (Player.Life != 0)
         {
-            Player.Remain--;
-            var inheritance = new Inheritance(skill);
-            // スキル継承クラスのスキルを継承させる関数呼び出し
-            inheritance.InheritSkill();
-            // プレイヤーをDestroyする関数呼び出し
-            enemy.PlayerKill(m_player);
-            SceneTransManager.TransToSkill();
+            Player.Life--;
+            #region 継承スキル数が上限に達していない&未継承スキルを獲得した場合
+            if (Player.m_inheritedSkills.Count < Player.InheritanceLimit
+                && !Player.m_inheritedSkills.Contains(skill))
+            {
+                var inheritance = new Inheritance(skill);
+                // スキル継承クラスのスキルを継承させる関数呼び出し
+                inheritance.InheritSkill();
+                // プレイヤーをDestroyする関数呼び出し
+                enemy.PlayerKill(m_player);
+                SceneTransManager.TransToSkill();
+            }
+            #endregion
+
+            #region 継承スキル数が上限に達していない&既に継承しているスキルを獲得した場合
+            else if (Player.m_inheritedSkills.Count < Player.InheritanceLimit
+                && Player.m_inheritedSkills.Contains(skill))
+            {
+                SceneTransManager.TransToMainGameLatest();
+            }
+            #endregion
+
+            #region 継承スキル数が上限に達した&未継承スキルを獲得した場合
+            else if (Player.m_inheritedSkills.Count == Player.InheritanceLimit
+                && !Player.m_inheritedSkills.Contains(skill))
+            {
+                Player.m_swapSkills.Add(skill);
+                enemy.PlayerKill(m_player);
+                SceneTransManager.TransToSkillSwap();
+            }
+            #endregion
         }
         else
         {
@@ -38,7 +63,9 @@ public class PlayerKillManager
             SceneTransManager.TransToGameOver();
         }
     }
+    #endregion
 
+    #region Gimmick
     /// <summary>
     /// ギミックがプレイヤーを倒す一連の処理
     /// </summary>
@@ -46,15 +73,39 @@ public class PlayerKillManager
     /// <param name="causeOfDeathType"></param>
     public void PlayerKill(Gimmick gimmick, Skill skill)
     {
-        if (Player.Remain != 0)
+        if (Player.Life != 0)
         {
-            Player.Remain--;
-            var inheritance = new Inheritance(skill);
-            // スキル継承クラスのスキルを継承させる関数呼び出し
-            inheritance.InheritSkill();
-            // プレイヤーをDestroyする関数呼び出し
-            gimmick.PlayerKill(m_player);
-            SceneTransManager.TransToSkill();
+            Player.Life--;
+            #region 継承スキル数が上限に達していない&未継承スキルを獲得した場合
+            if (Player.m_inheritedSkills.Count < Player.InheritanceLimit
+                && !Player.m_inheritedSkills.Contains(skill))
+            {
+                var inheritance = new Inheritance(skill);
+                // スキル継承クラスのスキルを継承させる関数呼び出し
+                inheritance.InheritSkill();
+                // プレイヤーをDestroyする関数呼び出し
+                gimmick.PlayerKill(m_player);
+                SceneTransManager.TransToSkill();
+            }
+            #endregion
+
+            #region 継承スキル数が上限に達していない&既に継承しているスキルを獲得した場合
+            else if (Player.m_inheritedSkills.Count < Player.InheritanceLimit
+                && Player.m_inheritedSkills.Contains(skill))
+            {
+                SceneTransManager.TransToMainGameLatest();
+            }
+            #endregion
+
+            #region 継承スキル数が上限に達した&未継承スキルを獲得した場合
+            else if (Player.m_inheritedSkills.Count == Player.InheritanceLimit
+                && !Player.m_inheritedSkills.Contains(skill))
+            {
+                Player.m_swapSkills.Add(skill);
+                gimmick.PlayerKill(m_player);
+                SceneTransManager.TransToSkillSwap();
+            }
+            #endregion
         }
         else
         {
@@ -62,4 +113,5 @@ public class PlayerKillManager
             SceneTransManager.TransToGameOver();
         }
     }
+    #endregion
 }

--- a/Assets/Scripts/SkillSceneManager.cs
+++ b/Assets/Scripts/SkillSceneManager.cs
@@ -24,7 +24,7 @@ public class SkillSceneManager : MonoBehaviour
         m_causeOfDeathText.text = $"{Inheritance.m_skill.DeathType}によって死亡した";
         m_skillAcquisitionText.text = $"{Inheritance.m_skill.SkillName}を獲得！";
         m_skillDescriptionText.text = Inheritance.m_skill.SkillDescription;
-        m_remainText.text = $"残機:{Player.Remain}";
+        m_remainText.text = $"残機:{Player.Life}";
     }
 
     /// <summary>

--- a/Assets/Scripts/TitleManager.cs
+++ b/Assets/Scripts/TitleManager.cs
@@ -8,7 +8,7 @@ public class TitleManager : MonoBehaviour
     void Start()
     {
         Player.m_inheritedSkills.Clear();
-        Player.Remain = 3;
+        Player.Life = 3;
     }
 
     // Update is called once per frame


### PR DESCRIPTION
close 159 残機が許す限りスキルを継承できてしまっていたため、スキルを継承できる数に上限を追加した

# 関連issue
Closes #159 

# 新機能
 スキル継承数に上限を追加した
プレイヤーが死んだ際にスキル数が上限に達していた場合スキル入れ替え画面に遷移する機能を実装した

# 機能修正

- 残機を5に変更した
- 残機の変数名とプロパティ名をそれぞれm_remain→m_life、Remain→Lifeに変更した

# 確認事項・確認手順

- [x] Assets\Scenes\SkillSwap.unity
- [x] Assets\Scripts\GameClearManager.cs
- [x] Assets\Scripts\GameOverManager.cs
- [x] Assets\Scripts\Player.cs
- [x] Assets\Scripts\PlayerKillManager.cs
- [x] Assets\Scripts\SkillSceneManager.cs
- [x] Assets\Scripts\TitleManager.cs
- [x] Assets\SO\Skill\DefeatTheKuribo.asset

# 備考
タイトル画面でのプレイヤーの残機セットアップが3のままなので、タイトル画面からゲームを開始した場合は残機は5にはなりません。
クリボーに倒された際の死因がトゲゾーになっていたため、クリボーに変更しました。
