### PR TITLE
[feature]トラップエリアにギミックとエネミーを配置した

### DIFF
--- a/Assets/Prefabs/SteelTrap.prefab
+++ b/Assets/Prefabs/SteelTrap.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &6044670653150227624
+--- !u!1 &5890898448293424005
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,37 +8,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7425294912470034162}
-  - component: {fileID: 1059201187201121932}
-  - component: {fileID: 421013807379628258}
+  - component: {fileID: 8534304356604109553}
+  - component: {fileID: 2920459384158124288}
+  - component: {fileID: 3160598513069708349}
   m_Layer: 0
-  m_Name: "\u30D0\u30AF\u30C0\u30F3\u30D0\u30CA"
+  m_Name: SteelTrap
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7425294912470034162
+--- !u!4 &8534304356604109553
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6044670653150227624}
+  m_GameObject: {fileID: 5890898448293424005}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.15265848, y: -0.08942944, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 20.11, y: 5.4, z: 0}
+  m_LocalScale: {x: 2, y: 0.5, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1059201187201121932
+--- !u!212 &2920459384158124288
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6044670653150227624}
+  m_GameObject: {fileID: 5890898448293424005}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -73,7 +73,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -83,16 +83,16 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &421013807379628258
+--- !u!114 &3160598513069708349
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6044670653150227624}
+  m_GameObject: {fileID: 5890898448293424005}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a57ed2504a18687469d45e8d016dfe56, type: 3}
+  m_Script: {fileID: 11500000, guid: 86770d0d757d1d6429103f406edb2758, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_explosionObj: {fileID: 6607643692884719038, guid: b1bddff0377a3b940aed1ab708fc410b, type: 3}
+  m_skill: {fileID: 0}

--- a/Assets/Prefabs/SteelTrap.prefab.meta
+++ b/Assets/Prefabs/SteelTrap.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff3b9e666f9ad2445a939c474647ffcb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Stage2.unity
+++ b/Assets/Scenes/Stage2.unity
@@ -193,6 +193,37 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
   m_PrefabInstance: {fileID: 384747305}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &77862480 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6044670653150227624, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+  m_PrefabInstance: {fileID: 158071066}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &77862484
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77862480}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 1}
+  m_EdgeRadius: 0
 --- !u!1001 &85955898
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -334,6 +365,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
   m_PrefabInstance: {fileID: 1099028619}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &158071066
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6044670653150227624, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_Name
+      value: "\u30D0\u30AF\u30C0\u30F3\u30D0\u30CA"
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.186583
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.665793
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
 --- !u!4 &163088464 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
@@ -396,7 +484,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &242111520 stripped
 Transform:
@@ -470,7 +558,7 @@ Transform:
   - {fileID: 157777376}
   - {fileID: 1563046388}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &277736476
 PrefabInstance:
@@ -1134,7 +1222,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &735111648 stripped
 MonoBehaviour:
@@ -1856,7 +1944,7 @@ Transform:
   m_Children:
   - {fileID: 461480810}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1236021506
 PrefabInstance:
@@ -2151,6 +2239,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
   m_PrefabInstance: {fileID: 85955898}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1407164634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1407164636}
+  - component: {fileID: 1407164635}
+  m_Layer: 0
+  m_Name: TrapArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1407164635
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407164634}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -3.4190063, y: 1.3311329}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 10.573212, y: 5.558674}
+  m_EdgeRadius: 0
+--- !u!4 &1407164636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407164634}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 20.3733, y: 6.544401, z: -22.566685}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1414026220
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2450,7 +2595,7 @@ PrefabInstance:
       objectReference: {fileID: 721062311}
     - target: {fileID: 7862410354438663238, guid: a631b48767b6d234abf0ebbb07c81902, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7862410354438663238, guid: a631b48767b6d234abf0ebbb07c81902, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3317,7 +3462,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6283140259448163271, guid: 0e1ca8f4cc18e30438ce146721244d03, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6283140259448163271, guid: 0e1ca8f4cc18e30438ce146721244d03, type: 3}
       propertyPath: m_LocalScale.x
@@ -3600,7 +3745,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2103954630
 MonoBehaviour:
@@ -3625,3 +3770,60 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
   m_PrefabInstance: {fileID: 1172322081}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1613333023405149280
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5890898448293424005, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_Name
+      value: SteelTrap
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534304356604109553, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ff3b9e666f9ad2445a939c474647ffcb, type: 3}

--- a/Assets/Scripts/SteelTrap.cs
+++ b/Assets/Scripts/SteelTrap.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SteelTrap : MonoBehaviour
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player"))
+        {
+            // プレイヤースクリプトを取得
+            var player = collision.GetComponent<Player>();
+            if (player != null)
+            {
+                Destroy(player.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/SteelTrap.cs.meta
+++ b/Assets/Scripts/SteelTrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86770d0d757d1d6429103f406edb2758
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TrapArea.cs
+++ b/Assets/Scripts/TrapArea.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TrapArea : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/TrapArea.cs.meta
+++ b/Assets/Scripts/TrapArea.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bf959512575e5245ba9cc244e5afcf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION


# 関連issue
#69 

# 新機能

-  トラップエリアにSteelTrap(トラバサミ)とバクダンバナを配置した
- トラップエリアの判定を取るための空オブジェクトを配置した
- PlayerがSteelTrapに触れると死ぬ機能を実装した(仮実装)

# 機能修正


# 確認事項・確認手順

- [x] Assets\Prefabs\バクダンバナ.prefab
- [x] Assets\Scenes\Stage2.unity
- [x] Assets\Prefabs\SteelTrap.prefab
- [x] Assets\Scripts\SteelTrap.cs
- [x] Assets\Scripts\TrapArea.cs

# 備考
SteelTrapとトラップエリア判定のオブジェクトは一旦仮置きです。バクダンバナのみ機能実装済み
