### PR TITLE
[fix]プレイヤーが壁に引っかかるバグを修正

### DIFF
--- a/Assets/Materials.meta
+++ b/Assets/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecd2114968eb68945b9d0402b2f0343b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/PlayerPhysicsMaterial2D.physicsMaterial2D
+++ b/Assets/Materials/PlayerPhysicsMaterial2D.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PlayerPhysicsMaterial2D
+  friction: 0.4
+  bounciness: 0

--- a/Assets/Materials/PlayerPhysicsMaterial2D.physicsMaterial2D.meta
+++ b/Assets/Materials/PlayerPhysicsMaterial2D.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37e336a7765c58541ba54b3b90858452
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 6200000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -46,7 +46,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 4073030105426006116}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 37e336a7765c58541ba54b3b90858452, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -328,6 +328,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7af13589e3786344bb386a5532e81ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_tutorialManager: {fileID: 0}
 --- !u!61 &7933490660062165046
 BoxCollider2D:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
close #27 プレイヤーが壁に引っかかってしまうバグを修正した

# 関連issue
Closes #27 
# 新機能
 

# 機能修正

- プレイヤーが壁に引っかかるバグを修正した

# 確認事項・確認手順

- [x] Assets\Prefabs\Player.prefab
- [x] Assets\Materials\PlayerPhysicsMaterial2D.physicsMaterial2D

# 備考
Materialsフォルダーを追加しました。プレイヤーの摩擦を0に変更。
