### PR TITLE
[feature]スキル合成画面に遷移する機能を実装

### DIFF
--- a/Assets/Scenes/SkillFusion.unity
+++ b/Assets/Scenes/SkillFusion.unity
@@ -123,7 +123,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &124301209
+--- !u!1 &272463712
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -131,104 +131,78 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 124301210}
-  - component: {fileID: 124301213}
-  - component: {fileID: 124301212}
-  - component: {fileID: 124301211}
+  - component: {fileID: 272463713}
+  - component: {fileID: 272463715}
+  - component: {fileID: 272463714}
   m_Layer: 5
-  m_Name: InheritedSkillSlotPanel
+  m_Name: NoSkillText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &124301210
+  m_IsActive: 0
+--- !u!224 &272463713
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 124301209}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 272463712}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2194430383123443865}
-  - {fileID: 1849358854}
-  - {fileID: 2045832540}
-  m_Father: {fileID: 1559532391}
-  m_RootOrder: 1
+  m_Children: []
+  m_Father: {fileID: 1511671996}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -270}
-  m_SizeDelta: {x: 0, y: -540}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 960, y: -270}
+  m_SizeDelta: {x: 500, y: 350}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &124301211
+--- !u!114 &272463714
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 124301209}
+  m_GameObject: {fileID: 272463712}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
---- !u!114 &124301212
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 124301209}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &124301213
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 02951c178c722bd40882e7778e881b63, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u5165\u308C\u66FF\u3048\u3089\u308C\u308B\u30B9\u30AD\u30EB\u304C\u3042\u308A\u307E\u305B\u3093"
+--- !u!222 &272463715
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 124301209}
+  m_GameObject: {fileID: 272463712}
   m_CullTransparentMesh: 1
---- !u!1 &366477990
+--- !u!1 &694204203
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -236,9 +210,195 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 366477991}
-  - component: {fileID: 366477993}
-  - component: {fileID: 366477992}
+  - component: {fileID: 694204206}
+  - component: {fileID: 694204205}
+  - component: {fileID: 694204204}
+  m_Layer: 0
+  m_Name: SkillSlotManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &694204204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 694204203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c398510bafd2b4c40abcc142ef558b9e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_slots:
+  - {fileID: 1754585802}
+  - {fileID: 1742338172}
+  - {fileID: 1949386766}
+  m_selectedSlot: {fileID: 745839668}
+--- !u!114 &694204205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 694204203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 484805b344158fa4ea71810fb145cf13, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_slotPrefab: {fileID: 6571831721466936945, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+  m_swapSkillSlotPanel: {fileID: 1317064385}
+  m_swapSkillSlots: []
+  m_inheritedSkillSlots:
+  - {fileID: 1754585801}
+  - {fileID: 1742338171}
+  - {fileID: 1949386765}
+  m_noSkillText: {fileID: 272463712}
+--- !u!4 &694204206
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 694204203}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.8309383, y: -0.6875255, z: -1.5161741}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &745839667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1511671996}
+    m_Modifications:
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 575
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 475
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875806, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_Name
+      value: SelectedImage
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883699613910875806, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+--- !u!114 &745839668 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3883699613910875804, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+  m_PrefabInstance: {fileID: 745839667}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &745839669 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+  m_PrefabInstance: {fileID: 745839667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1006399906
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1006399907}
+  - component: {fileID: 1006399909}
+  - component: {fileID: 1006399908}
   m_Layer: 5
   m_Name: SelectSkillText
   m_TagString: Untagged
@@ -246,18 +406,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &366477991
+--- !u!224 &1006399907
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 366477990}
+  m_GameObject: {fileID: 1006399906}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1559532391}
+  m_Father: {fileID: 1511671996}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -265,13 +425,13 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 507.5}
   m_SizeDelta: {x: 615, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &366477992
+--- !u!114 &1006399908
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 366477990}
+  m_GameObject: {fileID: 1006399906}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -298,16 +458,16 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u5165\u308C\u66FF\u3048\u308B\u30B9\u30AD\u30EB\u3092\u9078\u629E\u3057\u3066\u304F\u3060\u3055\u3044"
---- !u!222 &366477993
+  m_Text: "\u5408\u6210\u3059\u308B\u30B9\u30AD\u30EB\u3092\u9078\u629E\u3057\u3066\u304F\u3060\u3055\u3044"
+--- !u!222 &1006399909
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 366477990}
+  m_GameObject: {fileID: 1006399906}
   m_CullTransparentMesh: 1
---- !u!1 &418702683
+--- !u!1 &1317064385
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -315,9 +475,387 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 418702684}
-  - component: {fileID: 418702686}
-  - component: {fileID: 418702685}
+  - component: {fileID: 1317064386}
+  - component: {fileID: 1317064389}
+  - component: {fileID: 1317064388}
+  - component: {fileID: 1317064387}
+  m_Layer: 5
+  m_Name: SwapSkillSlotPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1317064386
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317064385}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1511671996}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 270}
+  m_SizeDelta: {x: 0, y: -540}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1317064387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317064385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 50
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &1317064388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317064385}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1317064389
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317064385}
+  m_CullTransparentMesh: 1
+--- !u!1 &1511671995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1511671996}
+  - component: {fileID: 1511671999}
+  - component: {fileID: 1511671998}
+  - component: {fileID: 1511671997}
+  m_Layer: 5
+  m_Name: SkillSlotCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1511671996
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1511671995}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1317064386}
+  - {fileID: 1522906992}
+  - {fileID: 745839669}
+  - {fileID: 1595208826}
+  - {fileID: 1006399907}
+  - {fileID: 272463713}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1511671997
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1511671995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1511671998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1511671995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1511671999
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1511671995}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &1522906991
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1522906992}
+  - component: {fileID: 1522906995}
+  - component: {fileID: 1522906994}
+  - component: {fileID: 1522906993}
+  m_Layer: 5
+  m_Name: InheritedSkillSlotPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1522906992
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522906991}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1754585800}
+  - {fileID: 1742338170}
+  - {fileID: 1949386764}
+  m_Father: {fileID: 1511671996}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -270}
+  m_SizeDelta: {x: 0, y: -540}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1522906993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522906991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &1522906994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522906991}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1522906995
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522906991}
+  m_CullTransparentMesh: 1
+--- !u!1 &1589448537
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1589448540}
+  - component: {fileID: 1589448539}
+  - component: {fileID: 1589448538}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1589448538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589448537}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1589448539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589448537}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1589448540
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589448537}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1595208825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1595208826}
+  - component: {fileID: 1595208828}
+  - component: {fileID: 1595208827}
   m_Layer: 5
   m_Name: InheritedSkillText
   m_TagString: Untagged
@@ -325,18 +863,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &418702684
+--- !u!224 &1595208826
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 418702683}
+  m_GameObject: {fileID: 1595208825}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1559532391}
+  m_Father: {fileID: 1511671996}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -344,13 +882,13 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -11.2}
   m_SizeDelta: {x: 500, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &418702685
+--- !u!114 &1595208827
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 418702683}
+  m_GameObject: {fileID: 1595208825}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
@@ -378,15 +916,15 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "\u2193\u7D99\u627F\u4E2D\u306E\u30B9\u30AD\u30EB\u2193"
---- !u!222 &418702686
+--- !u!222 &1595208828
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 418702683}
+  m_GameObject: {fileID: 1595208825}
   m_CullTransparentMesh: 1
---- !u!1 &580312798
+--- !u!1 &1611493413
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -394,78 +932,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 580312801}
-  - component: {fileID: 580312800}
-  - component: {fileID: 580312799}
-  m_Layer: 0
-  m_Name: SkillSlotManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &580312799
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580312798}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c398510bafd2b4c40abcc142ef558b9e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_slots:
-  - {fileID: 2013126155}
-  - {fileID: 741634147}
-  - {fileID: 634212414}
-  m_selectedSlot: {fileID: 2013242323}
---- !u!114 &580312800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580312798}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 484805b344158fa4ea71810fb145cf13, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_slotPrefab: {fileID: 6571831721466936945, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_swapSkillSlotPanel: {fileID: 666400974}
-  m_swapSkillSlots: []
-  m_inheritedSkillSlots:
-  - {fileID: 2013126153}
-  - {fileID: 741634145}
-  - {fileID: 634212412}
-  m_noSkillText: {fileID: 1173399411}
---- !u!4 &580312801
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 580312798}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 6.8309383, y: -0.6875255, z: -1.5161741}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &608149052
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 608149055}
-  - component: {fileID: 608149054}
-  - component: {fileID: 608149053}
+  - component: {fileID: 1611493416}
+  - component: {fileID: 1611493415}
+  - component: {fileID: 1611493414}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -473,21 +942,21 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &608149053
+--- !u!81 &1611493414
 AudioListener:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608149052}
+  m_GameObject: {fileID: 1611493413}
   m_Enabled: 1
---- !u!20 &608149054
+--- !u!20 &1611493415
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608149052}
+  m_GameObject: {fileID: 1611493413}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -524,13 +993,13 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!4 &608149055
+--- !u!4 &1611493416
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608149052}
+  m_GameObject: {fileID: 1611493413}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -538,408 +1007,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &634212412 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8171073375105338247, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 2045832539}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 952ce9662feae00408075cb5492bf45f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &634212414 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5176212481275076049, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 2045832539}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &650693475
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 650693478}
-  - component: {fileID: 650693477}
-  - component: {fileID: 650693476}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &650693476
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 650693475}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &650693477
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 650693475}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &650693478
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 650693475}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &666400974
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 666400975}
-  - component: {fileID: 666400978}
-  - component: {fileID: 666400977}
-  - component: {fileID: 666400976}
-  m_Layer: 5
-  m_Name: SwapSkillSlotPanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &666400975
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666400974}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1559532391}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 270}
-  m_SizeDelta: {x: 0, y: -540}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &666400976
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666400974}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 50
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
---- !u!114 &666400977
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666400974}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &666400978
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 666400974}
-  m_CullTransparentMesh: 1
---- !u!114 &741634145 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8171073375105338247, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 1849358853}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 952ce9662feae00408075cb5492bf45f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &741634147 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5176212481275076049, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 1849358853}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1173399411
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1173399412}
-  - component: {fileID: 1173399414}
-  - component: {fileID: 1173399413}
-  m_Layer: 5
-  m_Name: NoSkillText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1173399412
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1173399411}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1559532391}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -270}
-  m_SizeDelta: {x: 500, y: 350}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1173399413
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1173399411}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 02951c178c722bd40882e7778e881b63, type: 3}
-    m_FontSize: 30
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 50
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u5165\u308C\u66FF\u3048\u3089\u308C\u308B\u30B9\u30AD\u30EB\u304C\u3042\u308A\u307E\u305B\u3093"
---- !u!222 &1173399414
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1173399411}
-  m_CullTransparentMesh: 1
---- !u!1 &1559532387
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1559532391}
-  - component: {fileID: 1559532390}
-  - component: {fileID: 1559532389}
-  - component: {fileID: 1559532388}
-  m_Layer: 5
-  m_Name: SkillSlotCanvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1559532388
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559532387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &1559532389
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559532387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &1559532390
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559532387}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!224 &1559532391
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1559532387}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 666400975}
-  - {fileID: 124301210}
-  - {fileID: 2013242322}
-  - {fileID: 418702684}
-  - {fileID: 366477991}
-  - {fileID: 1173399412}
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!1001 &1849358853
+--- !u!1001 &1742338169
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 124301210}
+    m_TransformParent: {fileID: 1522906992}
     m_Modifications:
     - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_Pivot.x
@@ -1063,15 +1136,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
---- !u!224 &1849358854 stripped
+--- !u!224 &1742338170 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 1849358853}
+  m_PrefabInstance: {fileID: 1742338169}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &2013126153 stripped
+--- !u!114 &1742338171 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8171073375105338247, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 2194430383123443864}
+  m_PrefabInstance: {fileID: 1742338169}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1079,10 +1152,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 952ce9662feae00408075cb5492bf45f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &2013126155 stripped
+--- !u!114 &1742338172 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5176212481275076049, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 2194430383123443864}
+  m_PrefabInstance: {fileID: 1742338169}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1090,162 +1163,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2013242322 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
-  m_PrefabInstance: {fileID: 3883699613055917391}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2013242323 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3883699613910875804, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
-  m_PrefabInstance: {fileID: 3883699613055917391}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &2045832539
+--- !u!1001 &1754585799
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 124301210}
-    m_Modifications:
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 550
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 450
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6571831721466936945, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_Name
-      value: SkillSlot (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
---- !u!224 &2045832540 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 2045832539}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2194430383123443864
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 124301210}
+    m_TransformParent: {fileID: 1522906992}
     m_Modifications:
     - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_Pivot.x
@@ -1369,109 +1292,186 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
---- !u!224 &2194430383123443865 stripped
+--- !u!224 &1754585800 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
-  m_PrefabInstance: {fileID: 2194430383123443864}
+  m_PrefabInstance: {fileID: 1754585799}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &3883699613055917391
+--- !u!114 &1754585801 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8171073375105338247, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+  m_PrefabInstance: {fileID: 1754585799}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 952ce9662feae00408075cb5492bf45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1754585802 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5176212481275076049, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+  m_PrefabInstance: {fileID: 1754585799}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1949386763
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1559532391}
+    m_TransformParent: {fileID: 1522906992}
     m_Modifications:
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 575
+      value: 550
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 475
+      value: 450
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875805, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+    - target: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875806, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
-      propertyPath: m_Name
-      value: SelectedImage
+    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3883699613910875806, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
-      propertyPath: m_IsActive
-      value: 1
+    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4590073461940055231, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6571831721466936945, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_Name
+      value: SkillSlot (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7912881029837238799, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6aa60101157b7ae4abce6e3d8578d2a3, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+--- !u!224 &1949386764 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3039315252579574282, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+  m_PrefabInstance: {fileID: 1949386763}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1949386765 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8171073375105338247, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+  m_PrefabInstance: {fileID: 1949386763}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 952ce9662feae00408075cb5492bf45f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1949386766 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5176212481275076049, guid: bd63c355a3b3c1245a8a7a384fa77098, type: 3}
+  m_PrefabInstance: {fileID: 1949386763}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/SkillFusion.unity.meta
+++ b/Assets/Scenes/SkillFusion.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8bb94ec735734204d97fa0db24d2aee0
+guid: 5458665f703597649827244a9efb313f
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scenes/SkillSwap.unity
+++ b/Assets/Scenes/SkillSwap.unity
@@ -298,7 +298,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u5408\u6210\u3059\u308B\u30B9\u30AD\u30EB\u3092\u9078\u629E\u3057\u3066\u304F\u3060\u3055\u3044"
+  m_Text: "\u5165\u308C\u66FF\u3048\u308B\u30B9\u30AD\u30EB\u3092\u9078\u629E\u3057\u3066\u304F\u3060\u3055\u3044"
 --- !u!222 &366477993
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Stage2.unity
+++ b/Assets/Scenes/Stage2.unity
@@ -3399,27 +3399,27 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1310689756349022048, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1310689756349022048, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1310689756349022048, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1310689756349022048, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1310689756349022048, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 165.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1310689756349022048, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -95.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1310689756349022049, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_Name
@@ -3512,6 +3512,14 @@ PrefabInstance:
     - target: {fileID: 1310689757406939061, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
       propertyPath: m_Name
       value: TutorialCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310689757406939062, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 2103954628}
+    - target: {fileID: 1310689757406939062, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}
+      propertyPath: m_RenderMode
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 30b4e927911b64841923de6ac90ee5e6, type: 3}

--- a/Assets/Scripts/SceneTransManager.cs
+++ b/Assets/Scripts/SceneTransManager.cs
@@ -70,6 +70,14 @@ public class SceneTransManager
     }
 
     /// <summary>
+    /// スキル合成シーンに遷移する
+    /// </summary>
+    public static void TransToSkillFusion()
+    {
+        SceneManager.LoadScene("SkillFusion");
+    }
+
+    /// <summary>
     /// 直前のメインゲームシーンに遷移する
     /// </summary>
     public static void TransToMainGameLatest()

--- a/Assets/Scripts/Selection.cs
+++ b/Assets/Scripts/Selection.cs
@@ -57,6 +57,11 @@ public class Selection : MonoBehaviour
                 m_selection1 = true;
                 m_selection2 = false;
             }
+            // エンターキーを押したら
+            if (Input.GetKey(KeyCode.Return))
+            {
+                SceneTransManager.TransToSkillFusion();
+            }
         }
     }
 }

--- a/Assets/Scripts/TutorialController.cs
+++ b/Assets/Scripts/TutorialController.cs
@@ -30,7 +30,7 @@ public class TutorialController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        m_tutorialFramePos.position = Camera.main.WorldToScreenPoint(tutorialCharacterObj.transform.position + m_offset);
+        //m_tutorialFramePos.position = Camera.main.WorldToScreenPoint(tutorialCharacterObj.transform.position + m_offset);
     }
 
     /// <summary>
@@ -56,14 +56,14 @@ public class TutorialController : MonoBehaviour
     /// </summary>
     void SetDrawPos()
     {
-        //FrameRect = tutorialCanvasObj.transform.GetChild(0).GetComponent<RectTransform>();
-        //var framerectWidth = FrameRect.rect.width;
-        //var framerectHeght = FrameRect.rect.height;
+        FrameRect = tutorialCanvasObj.transform.GetChild(0).GetComponent<RectTransform>();
+        var framerectWidth = FrameRect.rect.width;
+        var framerectHeght = FrameRect.rect.height;
 
-        //FrameRect.anchoredPosition = new Vector2(
-        //    tutorialCharacterObj.transform.position.x + framerectWidth / 2.5f,
-        //    tutorialCharacterObj.transform.position.y + framerectHeght);
-        //Debug.Log(tutorialCharacterObj.transform.position.x);
+        FrameRect.anchoredPosition = new Vector2(
+            tutorialCharacterObj.transform.position.x + framerectWidth / 2.5f,
+            tutorialCharacterObj.transform.position.y + framerectHeght);
+        Debug.Log(tutorialCharacterObj.transform.position.x);
     }
 
     /// <summary>

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -32,4 +32,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/SkillSwap.unity
     guid: 1af85f147e14cc24491dc353020fcbfc
+  - enabled: 1
+    path: Assets/Scenes/SkillFusion.unity
+    guid: db75faaf435fd5c4594e0a4638a9746e
   m_configObjects: {}


### PR DESCRIPTION


# 関連issue
 

# 新機能
 

- プレイヤーが拠点でチュートリアルキャラにインタラクト→スキル合成をするを選択するとスキル合成画面に遷移する機能を実装した

# 機能修正


# 確認事項・確認手順

- [x] Assets\Scenes\SkillFusion.unity
- [x] Assets\Scenes\SkillSwap.unity
- [x] Assets\Scenes\Stage2.unity
- [x] Assets\Scripts\SceneTransManager.cs
- [x] Assets\Scripts\Selection.cs
- [x] Assets\Scripts\TutorialController.cs

# 備考

