### PR TITLE
[fix]ステージ2縦方向のスケール調整

### DIFF
--- a/Assets/Scenes/Stage2.unity
+++ b/Assets/Scenes/Stage2.unity
@@ -152,7 +152,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.5
+      value: 2.75
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -437,6 +437,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2039800586}
     m_Modifications:
+    - target: {fileID: 6490258290470593882, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.24999993
+      objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_RootOrder
       value: 7
@@ -604,6 +608,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: a6043315bbe6439428b18f9c85a222e1, type: 2}
   - {fileID: 11400000, guid: 61bed53d73b4d4b4baadb74a7a970071, type: 2}
   - {fileID: 11400000, guid: b32b14e507ea27c4aa4fe09869aa0902, type: 2}
+  - {fileID: 11400000, guid: 2d344927ae246894584d5c05862caceb, type: 2}
 --- !u!4 &228269477
 Transform:
   m_ObjectHideFlags: 0
@@ -712,7 +717,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalScale.y
-      value: 6.3
+      value: 8.3
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.x
@@ -720,7 +725,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -837,11 +842,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.5990314
+      value: -5.36
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.8379405
+      value: 4.83794
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1037,7 +1042,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalScale.y
@@ -1045,11 +1050,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6
+      value: 7.5
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1118,7 +1123,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11
+      value: 14.25
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1181,7 +1186,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.83794
+      value: 8.83794
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1255,7 +1260,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1415,7 +1420,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1524109956066327102, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 11.8968315
+      value: 15.1468315
       objectReference: {fileID: 0}
     - target: {fileID: 1524109956066327102, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1448,6 +1453,14 @@ PrefabInstance:
     - target: {fileID: 1524109956066327102, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2933373658431523118, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
+      propertyPath: m_Size.x
+      value: 1.4791255
+      objectReference: {fileID: 0}
+    - target: {fileID: 2933373658431523118, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.26043725
       objectReference: {fileID: 0}
     - target: {fileID: 5459202410474543387, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_Name
@@ -1504,7 +1517,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.5
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1651,7 +1664,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.5
+      value: 9.25
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1773,7 +1786,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1937,7 +1950,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.25
+      value: 7.75
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2051,7 +2064,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.45
+      value: 10.7
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2120,7 +2133,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2189,7 +2202,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2246,7 +2259,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.665792
+      value: 12.665792
       objectReference: {fileID: 0}
     - target: {fileID: 7425294912470034162, guid: 02938acf354faee48aa5cba3ecf2f40e, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2311,7 +2324,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 8.5
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2385,7 +2398,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2450,7 +2463,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.5
+      value: 2.75
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2834,7 +2847,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 6876436197685197661, guid: fe2929f88add97247a57ec9b1c31dba5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2970,7 +2983,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3044,7 +3057,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.75
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3113,7 +3126,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3178,7 +3191,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.25
+      value: 15.5
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3447,11 +3460,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1524109956066327102, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.0236864
+      value: -4.7736864
       objectReference: {fileID: 0}
     - target: {fileID: 1524109956066327102, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.825937
+      value: 12.825937
       objectReference: {fileID: 0}
     - target: {fileID: 1524109956066327102, guid: c30a25adcec80ff4284bfd36c3baea63, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3529,7 +3542,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3603,7 +3616,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7
+      value: 9.25
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3661,7 +3674,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1330502817698851750, guid: 262e7d2ced1ce2a4dafe27c4ace1d2b9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.803737
+      value: 12.803737
       objectReference: {fileID: 0}
     - target: {fileID: 1330502817698851750, guid: 262e7d2ced1ce2a4dafe27c4ace1d2b9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3734,7 +3747,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3872,7 +3885,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3925,7 +3938,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.8379405
+      value: 4.83794
       objectReference: {fileID: 0}
     - target: {fileID: 6993714881092385090, guid: cb8bf3403b997ca43b5f0f170a861776, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3998,7 +4011,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.5
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4334,7 +4347,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.75
+      value: 8.5
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4419,7 +4432,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4591,7 +4604,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.5
+      value: 6.75
       objectReference: {fileID: 0}
     - target: {fileID: 5352779641257991251, guid: 72df426115a5a1b4584c588056720ad2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4674,7 +4687,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4743,7 +4756,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 936431335426548859, guid: cca45995d70ca7f4d9a3e57afef4f751, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/JumpPowerEnhancement.cs
+++ b/Assets/Scripts/JumpPowerEnhancement.cs
@@ -16,7 +16,7 @@ public class JumpPowerEnhancement : SkillEffect
         }
         else
         {
-            player.JumpPower = 300f;
+            player.JumpPower = 350f;
         }
     }
 }


### PR DESCRIPTION
拠点のトリガーサイズ調整、縦方向のスケール調整に伴いプレイヤーの初期ジャンプ力も調整しました。

# 関連issue
close #85 

# 新機能
 

# 機能修正

- ステージ2の壁のY軸スケールを調整した
- 第2拠点のトリガーサイズを調整した(壁からはみ出していたため)
- プレイヤーの初期ジャンプ力を300f→350fに修正した
- ステージ2のクリボー踏んづけスキルのScriptableObjectが参照から外れていたため修正した

# 確認事項・確認手順

- [x] Assets\Scenes\Stage2.unity
- [x] Assets\Scripts\JumpPowerEnhancement.cs

# 備考

