### PR TITLE
[feature]プレイヤーキャラがドッスンに近づくとドッスンが落下する機能を実装

### DIFF
--- a/Assets/Prefabs/Dossun.prefab
+++ b/Assets/Prefabs/Dossun.prefab
@@ -11,6 +11,9 @@ GameObject:
   - component: {fileID: 1397842676170426767}
   - component: {fileID: 1397842676170426760}
   - component: {fileID: 1397842676170426761}
+  - component: {fileID: 8175711510585925972}
+  - component: {fileID: 5492944105110165852}
+  - component: {fileID: 175355704810624044}
   m_Layer: 0
   m_Name: Dossun
   m_TagString: Untagged
@@ -102,3 +105,76 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!50 &8175711510585925972
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397842676170426762}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &5492944105110165852
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397842676170426762}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.6214544}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.38, y: 0.5}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.7570912}
+  m_EdgeRadius: 0
+--- !u!61 &175355704810624044
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397842676170426762}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.38, y: 0.5}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.38, y: 0.5}
+  m_EdgeRadius: 0

--- a/Assets/Scripts/Dossun.cs
+++ b/Assets/Scripts/Dossun.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class Dossun : Enemy
+{
+    private Rigidbody2D rb2D;
+    [SerializeField, Header("コライダー")]
+    private BoxCollider2D m_coll;
+    [SerializeField, Header("トリガーコライダー")]
+    private BoxCollider2D m_triggerColl;
+
+    public override void ExecutePlayerKillManager(Player player)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public override void PlayerKill(Player player)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    private void Start()
+    {
+        rb2D = GetComponent<Rigidbody2D>();
+        rb2D.bodyType = RigidbodyType2D.Kinematic;
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player"))
+        {
+            rb2D.bodyType = RigidbodyType2D.Dynamic;
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
+}

--- a/Assets/Scripts/Dossun.cs.meta
+++ b/Assets/Scripts/Dossun.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39a8dff0146a03745833c8cab3718dd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ドッスンプレハブにトリガー(落下判定用)とトリガーなし(プレイヤーキル判定用)のコライダーを追加した

# 関連issue

# 新機能

-  プレイヤーキャラがドッスンのトリガー範囲に接触するとドッスンが落下する機能を実装した

# 機能修正


# 確認事項・確認手順

- [x] Assets\Prefabs\Dossun.prefab
- [x] Assets\Scripts\Dossun.cs

# 備考

