### PR TITLE
[feature]ドッスンがプレイヤーを倒す機能を実装

### DIFF
--- a/Assets/Prefabs/Dossun.prefab
+++ b/Assets/Prefabs/Dossun.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8175711510585925972}
   - component: {fileID: 5492944105110165852}
   - component: {fileID: 175355704810624044}
+  - component: {fileID: 7511861106692068588}
   m_Layer: 0
   m_Name: Dossun
   m_TagString: Untagged
@@ -31,7 +32,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2.5, y: 2.5, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 3619096891785244756}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -139,7 +141,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: -0.6214544}
+  m_Offset: {x: 0, y: -0.5888544}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -150,7 +152,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1, y: 1.7570912}
+  m_Size: {x: 1, y: 1.8222913}
   m_EdgeRadius: 0
 --- !u!61 &175355704810624044
 BoxCollider2D:
@@ -165,7 +167,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0.011642873, y: -0.2957291}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -176,5 +178,75 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.38, y: 0.5}
+  m_Size: {x: 0.27288556, y: 0.048256516}
+  m_EdgeRadius: 0
+--- !u!114 &7511861106692068588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397842676170426762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39a8dff0146a03745833c8cab3718dd6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_skill: {fileID: 11400000, guid: 76f8fbde1092ef340bd4f5c5f03f8486, type: 2}
+--- !u!1 &8281592421785834316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3619096891785244756}
+  - component: {fileID: 2942949371750718701}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3619096891785244756
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8281592421785834316}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1397842676170426767}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2942949371750718701
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8281592421785834316}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.000000029802322, y: 0.000000029802322}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.4038847, y: 0.49702775}
   m_EdgeRadius: 0

--- a/Assets/Scripts/Dossun.cs
+++ b/Assets/Scripts/Dossun.cs
@@ -6,19 +6,16 @@ using UnityEngine;
 public class Dossun : Enemy
 {
     private Rigidbody2D rb2D;
-    [SerializeField, Header("コライダー")]
-    private BoxCollider2D m_coll;
-    [SerializeField, Header("トリガーコライダー")]
-    private BoxCollider2D m_triggerColl;
 
     public override void ExecutePlayerKillManager(Player player)
     {
-        throw new System.NotImplementedException();
+        var playerKillManager = new PlayerKillManager(player);
+        playerKillManager.PlayerKill(this, m_skill);
     }
 
     public override void PlayerKill(Player player)
     {
-        throw new System.NotImplementedException();
+        Destroy(player.gameObject);
     }
 
     private void Start()
@@ -35,9 +32,17 @@ public class Dossun : Enemy
         }
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnCollisionEnter2D(Collision2D collision)
     {
+        if (collision.gameObject.CompareTag("Player"))
+        {
+            var player = collision.gameObject.GetComponent<Player>();
 
+            // 圧死耐性スキルが継承されていない、かつplayerがnullでなければ実行
+            if (!player.IsPressureResistanceEnabled && player != null)
+            {
+                ExecutePlayerKillManager(player);
+            }
+        }
     }
 }


### PR DESCRIPTION
ドッスンがプレイヤーと接触するとプレイヤーが死亡する機能を実装した。圧死耐性スキルを継承する機能も実装した

# 関連issue


# 新機能

-  ドッスンのコライダーとプレイヤーのコライダーが接触するとプレイヤーキャラが死亡する機能を実装した
- ドッスンと接触してプレイヤーキャラが死亡し、プレイヤーが圧死耐性を継承していない場合、圧死耐性を継承する機能を実装した

# 機能修正


# 確認事項・確認手順

- [x] Assets\Prefabs\Dossun.prefab
- [x] Assets\Scripts\Dossun.cs

# 備考

